### PR TITLE
example new content

### DIFF
--- a/content/en/publications/article-demo.md
+++ b/content/en/publications/article-demo.md
@@ -73,6 +73,54 @@ This is an ordered list:
 4. list item 4
 
 
+Image example: 
+
+    <img src="http://lorempixel.com/400/200/" />
+
+<img src="http://lorempixel.com/400/200/" />
+
+Image in block:
+
+    <div class="block image cutcorners w-7 h-4 row">
+        <img src="https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg" alt="">
+    </div>
+
+
+<div class="block image cutcorners w-7 h-4 row">
+    <img src="https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg" alt="">
+</div>
+
+
+Image in block with info:
+
+    <div class="block cutcorners w-7 h-4 row">
+        <div class="block image cutcorners w-4 h-4">
+            <img src="https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg" alt="" />
+        </div>
+        <div class="block info cutcorners w-3 h-4">
+            <div class="text">
+                <p>Geodesy instructor Jan Ebbinge operating a spirit level on campus in preparation for an open day of the Faculty of Geodesy around 1980.</p>
+                <p class="facts">Faculty of Architecture and the Built Environment / OTB Photo Archive / Photo: Axel Smitsod magnimust ipid.</p>
+            </div>
+        </div>
+    </div>
+
+
+<div class="block cutcorners w-7 h-4 row">
+    <div class="block image cutcorners w-4 h-4">
+        <img src="https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg" alt="" />
+    </div>
+    <div class="block info cutcorners w-3 h-4">
+        <div class="text">
+            <p>Geodesy instructor Jan Ebbinge operating a spirit level on campus in preparation for an open day of the Faculty of Geodesy around 1980.</p>
+            <p class="facts">Faculty of Architecture and the Built Environment / OTB Photo Archive / Photo: Axel Smitsod magnimust ipid.</p>
+        </div>
+    </div>
+</div>
+
+
+
+
 Quisque suscipit, mauris id vestibulum euismod, felis elit vulputate augue, eu aliquam purus massa eu dolor. Sed efficitur placerat turpis et fermentum. Donec a sodales leo. Phasellus in magna malesuada, laoreet nisi id, condimentum neque. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ut luctus nulla. Nullam luctus enim non pulvinar hendrerit. Sed ante lacus, sodales eget nunc id, cursus rhoncus ipsum. Fusce nisl ligula, congue a augue sed, vestibulum suscipit leo.
 
 Aliquam fermentum vestibulum nisl a porttitor. Fusce ultrices dui sit amet semper dictum. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Mauris sit amet massa sed lorem rhoncus ultrices quis id augue. Nunc est elit, ornare interdum nibh eget, aliquet convallis lectus. Curabitur a aliquam justo. Quisque rutrum efficitur ligula, id efficitur lorem fermentum a.

--- a/content/en/publications/article-demo.md
+++ b/content/en/publications/article-demo.md
@@ -75,9 +75,9 @@ This is an ordered list:
 
 Image example: 
 
-    <img src="http://lorempixel.com/400/200/" />
+    <img src="//lorempixel.com/400/200/" />
 
-<img src="http://lorempixel.com/400/200/" />
+<img src="//lorempixel.com/400/200/" />
 
 Image in block:
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -182,7 +182,7 @@ const createObjectPages = () => {
 
         // TODO: cover image if defined, first canvas thumbnail as fall-back,
         // than first canvas image fallback...
-        meta.thumbnails[pathname] = getManifestThumbnail(context); // context.items[0].thumbnail[0].id;
+        meta.thumbnails[pathname] = getManifestThumbnail(context);
         console.log(pathname, meta.thumbnails[pathname]);
         meta.links[context.id] = pathname;
         meta.reverseLinks[pathname] = context.id;
@@ -206,17 +206,12 @@ const createExhibitionPages = () => {
     .reduce(
       (meta, item) => {
         const [pathname, context] = getManifestContext(item);
-        // createTranslatedPage({
-        //   path: pathname,
-        //   component: exhibitionTemplate,
-        //   context,
-        // }, createPage);
         meta.pages[pathname] = {
           path: pathname,
           component: exhibitionTemplate,
           context,
         };
-        meta.thumbnails[pathname] = getManifestThumbnail(context); // /context.items[0].thumbnail[0].id || context.items[0].thumbnail[0]['@id'];
+        meta.thumbnails[pathname] = getManifestThumbnail(context);
         meta.links[(context.id || context['@id'])] = pathname;
         meta.reverseLinks[pathname] = (context.id || context['@id']);
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -52,13 +52,28 @@ const getAllAnnotationsFromManifest = (
       const processAnnotationPage = (annotationPage) => {
         (annotationPage.items || []).forEach(
           (annotation) => {
-            const annotationId = annotation.service && annotation.service.length > 0
-              ? annotation.service[0].id
-              : annotation.id;
-            if (!annotations[annotationId]) {
-              annotations[annotationId] = [];
+            // console.log(annotation.service);
+            let annotationId = annotation.id;
+            if (annotation.body && annotation.body.type === 'Image') {
+              if (annotation.body.service) {
+                const service = Array.isArray(annotation.body.service)
+                  ? annotation.body.service[0]
+                  : annotation.body.service;
+                if (typeof service === 'string') {
+                  annotationId = service;
+                } else if (typeof service.id === 'string') {
+                  annotationId = service.id;
+                }
+              }
+              if (annotationId === annotation.id && typeof annotation.body.id === 'string') {
+                annotationId = annotation.body.id;
+              }
+
+              if (!annotations[annotationId]) {
+                annotations[annotationId] = [];
+              }
+              annotations[annotationId].push([manifest.id, manifestPath, manifest.label]);
             }
-            annotations[annotationId].push([manifest.id, manifestPath, manifest.label]);
           },
         );
       };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -307,9 +307,13 @@ exports.createPages = ({ actions, graphql }) => {
     Object.values(objectMeta.pages).forEach(
       (object) => {
         object.context.collections = collectionMeta.objectInCollections[object.context.id];
+
+        const annos = Object.entries(objectMeta.annotationsPartOfObjects)
+            .filter(([key, value]) => value.filter(item => item[1] === object.path).length > 0)
+            .map(([key]) => key);
+
         object.context.exhibitions = Object.values(
-          Object.keys(objectMeta.annotationsPartOfObjects)
-            .reduce((_exhibitions, annotation) => {
+          annos.reduce((_exhibitions, annotation) => {
               if (exhibitionMeta.annotationsPartOfExhibition[annotation]) {
                 exhibitionMeta.annotationsPartOfExhibition[annotation].forEach(
                   (exhibition) => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -183,7 +183,6 @@ const createObjectPages = () => {
         // TODO: cover image if defined, first canvas thumbnail as fall-back,
         // than first canvas image fallback...
         meta.thumbnails[pathname] = getManifestThumbnail(context);
-        console.log(pathname, meta.thumbnails[pathname]);
         meta.links[context.id] = pathname;
         meta.reverseLinks[pathname] = context.id;
         getAllAnnotationsFromManifest(context, pathname, meta.annotationsPartOfObjects);
@@ -237,7 +236,7 @@ exports.createPages = ({ actions, graphql }) => {
 
   // console.log(JSON.stringify(exhibitionMeta.annotationsPartOfExhibition, null, 2));
   // console.log(JSON.stringify(objectMeta.annotationsPartOfObjects, null, 2));
-  console.log(JSON.stringify(collectionMeta.objectInCollections, null, 2));
+  // console.log(JSON.stringify(collectionMeta.objectInCollections, null, 2));
 
   return graphql(`
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -52,7 +52,6 @@ const getAllAnnotationsFromManifest = (
       const processAnnotationPage = (annotationPage) => {
         (annotationPage.items || []).forEach(
           (annotation) => {
-            // console.log(annotation.service);
             let annotationId = annotation.id;
             if (annotation.body && annotation.body.type === 'Image') {
               if (annotation.body.service) {
@@ -328,7 +327,18 @@ exports.createPages = ({ actions, graphql }) => {
       },
     );
     Object.values(exhibitionMeta.pages).forEach(
-      exhibition => createTranslatedPage(exhibition, createPage),
+      (exhibition) => {
+        const annos = Object.entries(exhibitionMeta.annotationsPartOfExhibition)
+          .filter(([key, value]) => value.filter(item => item[1] === exhibition.path).length > 0)
+          .reduce((_annos, [key]) => {
+            try {
+              _annos[key] = objectMeta.annotationsPartOfObjects[key][0][1];
+            } catch (err) {}
+            return _annos;
+          }, {});
+        exhibition.context.annotationDetails = annos;
+        createTranslatedPage(exhibition, createPage);
+      },
     );
     Object.values(collectionMeta.pages).forEach(
       collection => createTranslatedPage(collection, createPage),

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react": "^16.6.3",
     "react-container-dimensions": "^1.4.1",
     "react-dom": "^16.6.3",
-    "react-helmet": "^5.2.0"
+    "react-helmet": "^5.2.0",
+    "react-translate": "^6.1.0"
   },
   "keywords": [
     "gatsby"

--- a/src/collections/another-collection.json
+++ b/src/collections/another-collection.json
@@ -1,10 +1,10 @@
 {
     "label": {
       "en": [
-        "Test collection 1"
+        "Another Test collection"
       ],
       "nl": [
-        "Eerste test verzameling"
+        "Nog een testcollectie"
       ]
     },
     "summary": { 

--- a/src/collections/test.json
+++ b/src/collections/test.json
@@ -301,10 +301,10 @@
       },
       "thumbnail": [
         { 
-          "id": "https://dlc.services/thumbs/5/1/dbc3f644-5830-4d71-87c9-db12e35d1964/full/full/0/default.jpg", 
+          "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpg", 
           "service": {
             "@context":"http://iiif.io/api/image/2/context.json",
-            "@id":"https://dlc.services/thumbs/5/1/dbc3f644-5830-4d71-87c9-db12e35d1964",
+            "@id":"https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009",
             "profile": [
               "http://iiif.io/api/image/2/level0.json",
               {

--- a/src/components/CanvasModal/CanvasModal.js
+++ b/src/components/CanvasModal/CanvasModal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
 import ContainerDimensions from 'react-container-dimensions';
 import { Arrow } from '../Arrow/Arrow';
 import { Close } from '../Close/Close';
@@ -45,67 +46,85 @@ class CanvasModal extends React.Component {
             <ContainerDimensions>
               {({ width, height }) => (
                 <div className="canvas-modal__content" style={{ width: width - 64, height: Math.floor(height - 64) }}>
-                  <div className="canvas-modal__inner-frame">
-                    <div className="canvas-modal__content-slide">
-                      <div className="canvas-modal__top-part">
-                        <ThinCanvasPanel
-                          canvas={selectedCanvas}
-                          navItemsCallback={this.navItemsCallback}
-                          currentNavItem={currentNavItem}
-                        />
-                      </div>
-                      <div className="canvas-modal__info-and-nav">
-                        <div className="canvas-modal__info">
-                          {currentLabelAndDescriptionSource.label ? (
-                            <h6>
-                              {getTranslation(currentLabelAndDescriptionSource.label, pageLanguage)}
-                            </h6>
-                          ) : '' }
-                          {currentLabelAndDescriptionSource.summary ? (
-                            <p>
-                              {getTranslation(
-                                currentLabelAndDescriptionSource.summary, pageLanguage,
-                              )}
-                            </p>
-                          ) : ''}
+
+                  {(selectedCanvas.behavior || []).indexOf('info') !== -1 ? (
+                    <div className="canvas-modal__essay">
+                      {annotations.map(annotation => (
+                        <main>
+                          { annotation.label && (
+                            <h3>{getTranslation(annotation.label, pageLanguage)}</h3>
+                          )}
+                          { annotation.summary && getTranslation(annotation.summary, pageLanguage, '\n')
+                            .split('\n')
+                            .map(paragraph => <p key={`about__${paragraph}`}>{paragraph}</p>)
+                          }
+                        </main>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="canvas-modal__inner-frame">
+                      <div className="canvas-modal__content-slide">
+                        <div className="canvas-modal__top-part">
+                          <ThinCanvasPanel
+                            canvas={selectedCanvas}
+                            navItemsCallback={this.navItemsCallback}
+                            currentNavItem={currentNavItem}
+                          />
                         </div>
-                        {navItems.length > 1 ? (
-                          <div className="canvas-modal__nav">
-                            {currentNavItem + 1}
-                            {' / '}
-                            {navItems.length}
+                        <div className="canvas-modal__info-and-nav">
+                          <div className="canvas-modal__info">
+                            {currentLabelAndDescriptionSource.label ? (
+                              <h6>
+                                {getTranslation(currentLabelAndDescriptionSource.label, pageLanguage)}
+                              </h6>
+                            ) : '' }
+                            {currentLabelAndDescriptionSource.summary ? (
+                              <p>
+                                {getTranslation(
+                                  currentLabelAndDescriptionSource.summary, pageLanguage,
+                                )}
+                              </p>
+                            ) : ''}
                           </div>
-                              ) : ''}
-                        {navItems.length > 1 ? (
-                          <div className="canvas-modal__nav">
-                            <button
-                              className="arrow left"
-                              onClick={() => this.setState({ currentNavItem: currentNavItem - 1 })}
-                              type="button"
-                              style={{
-                                  visibility: currentNavItem === 0 ? 'hidden' : 'visible',
+                          <div className="canvas-modal__nav"><Link to={[pageLanguage, 'objects/multi-canvas-object'].join('/')}>View Details</Link></div>
+                          {navItems.length > 1 ? (
+                            <div className="canvas-modal__nav">
+                              {currentNavItem + 1}
+                              {' / '}
+                              {navItems.length}
+                            </div>
+                                ) : ''}
+                          {navItems.length > 1 ? (
+                            <div className="canvas-modal__nav">
+                              <button
+                                className="arrow left"
+                                onClick={() => this.setState({ currentNavItem: currentNavItem - 1 })}
+                                type="button"
+                                style={{
+                                    visibility: currentNavItem === 0 ? 'hidden' : 'visible',
+                                  }}
+                              >
+                                <Arrow />
+                              </button>
+                              <button
+                                className="arrow right"
+                                onClick={() => this.setState({ currentNavItem: currentNavItem + 1 })}
+                                type="button"
+                                style={{
+                                  visibility:
+                                    currentNavItem + 1 === navItems.length
+                                      ? 'hidden'
+                                      : 'visible',
                                 }}
-                            >
-                              <Arrow />
-                            </button>
-                            <button
-                              className="arrow right"
-                              onClick={() => this.setState({ currentNavItem: currentNavItem + 1 })}
-                              type="button"
-                              style={{
-                                visibility:
-                                  currentNavItem + 1 === navItems.length
-                                    ? 'hidden'
-                                    : 'visible',
-                              }}
-                            >
-                              <Arrow />
-                            </button>
-                          </div>
-                              ) : ''}
+                              >
+                                <Arrow />
+                              </button>
+                            </div>
+                                ) : ''}
+                        </div>
                       </div>
                     </div>
-                  </div>
+                  )}
                   <button
                     onClick={hideCanvasDetails}
                     className="canvas-modal__close"

--- a/src/components/CanvasModal/CanvasModal.scss
+++ b/src/components/CanvasModal/CanvasModal.scss
@@ -14,6 +14,7 @@
     display: flex;
     flex-direction: column;
   }
+  
   &__close {
     display: flex;
     position: absolute;
@@ -42,6 +43,18 @@
     flex-direction: column;
     height: 100%;
   }
+
+  &__essay {
+    height: 100%;
+    width: 100%; 
+    overflow-y: auto;
+    overflow-x: hidden;
+    background: #fff;
+    &+.canvas-modal__close svg polygon {
+      fill: #000 !important;
+    }
+  }
+
   &__content-slide {
     flex: 1;
     display: flex;

--- a/src/components/Header/header.js
+++ b/src/components/Header/header.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as classnames from 'classnames';
+import { translate } from 'react-translate';
 import { Link } from 'gatsby';
 import Menu from '../Menu/menu';
 import Logo from '../Logo/logo';
 import BurgerMenu from '../BurgerMenu/BurgerMenu';
 import LanguageSelector from '../LanguageSelector/languageSelector';
 import './header.css';
+
 
 class Header extends React.Component {
   state = {
@@ -21,14 +23,15 @@ class Header extends React.Component {
   }
 
   render() {
-    const { siteTitle, language, path } = this.props;
+    const { language, path, t } = this.props;
     const { isMobileMenuOpen } = this.state;
+    console.log(t);
     return (
       <header className="header">
         <div className="header__content">
           <BurgerMenu className="header__burger-menu" onClick={this.toggleMobileMenu} />
           <Link to={`/${language}/`} className="header__site-title">
-            {siteTitle}
+            {t('SITE_TITLE')}
           </Link>
           <div
             className={
@@ -46,9 +49,13 @@ class Header extends React.Component {
 }
 
 Header.propTypes = {
-  siteTitle: PropTypes.string.isRequired,
+  t: PropTypes.func,
   language: PropTypes.string.isRequired,
   path: PropTypes.string.isRequired,
 };
 
-export default Header;
+Header.defaultProps = {
+  t: key => key,
+};
+
+export default translate('Header')(Header);

--- a/src/components/Header/header.js
+++ b/src/components/Header/header.js
@@ -25,7 +25,6 @@ class Header extends React.Component {
   render() {
     const { language, path, t } = this.props;
     const { isMobileMenuOpen } = this.state;
-    console.log(t);
     return (
       <header className="header">
         <div className="header__content">

--- a/src/components/Layout/layout.js
+++ b/src/components/Layout/layout.js
@@ -22,7 +22,7 @@ const Layout = ({ children, language, path }) => (
         }
       `}
     render={data => (
-      <TranslatorProvider translations={translations[language]}>
+      <TranslatorProvider translations={translations[language] || translations.en}>
         <React.Fragment>
           <Helmet
             title={data.site.siteMetadata.title}

--- a/src/components/Layout/layout.js
+++ b/src/components/Layout/layout.js
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { StaticQuery, graphql } from 'gatsby';
-
+import { TranslatorProvider } from 'react-translate';
 import Header from '../Header/header';
 import Footer from '../Footer/footer';
 import './layout.css';
 import '../delft-styles.scss';
 
+import translations from '../../translations';
 
 const Layout = ({ children, language, path }) => (
   <StaticQuery
@@ -21,20 +22,22 @@ const Layout = ({ children, language, path }) => (
         }
       `}
     render={data => (
-      <React.Fragment>
-        <Helmet
-          title={data.site.siteMetadata.title}
-          meta={[
-              { name: 'description', content: 'Sample' },
-              { name: 'keywords', content: 'sample, something' },
-            ]}
-        >
-          <html lang={language} />
-        </Helmet>
-        <Header siteTitle={data.site.siteMetadata.title} language={language} path={path} />
-        {children}
-        <Footer />
-      </React.Fragment>
+      <TranslatorProvider translations={translations[language]}>
+        <React.Fragment>
+          <Helmet
+            title={data.site.siteMetadata.title}
+            meta={[
+                { name: 'description', content: 'Sample' },
+                { name: 'keywords', content: 'sample, something' },
+              ]}
+          >
+            <html lang={language} />
+          </Helmet>
+          <Header language={language} path={path} />
+          {children}
+          <Footer />
+        </React.Fragment>
+      </TranslatorProvider>
       )}
   />
 );

--- a/src/components/ManifestCabinet/ManifestCabinet.js
+++ b/src/components/ManifestCabinet/ManifestCabinet.js
@@ -1,44 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withBemClass } from '@canvas-panel/core';
+import { thumbnailGetSize } from '../../utils';
 import './ManifestCabinet.scss';
-
-const thumbnailGetSize = (thumbnail, pWidth, pHeight) => {
-  const thumb = thumbnail.__jsonld;
-  if (
-    (pWidth || pHeight)
-    && thumb.hasOwnProperty('service')
-    && thumb.service.hasOwnProperty('sizes')
-  ) {
-    let closestSizeIndex = -1;
-    let minDistanceX = Number.MAX_SAFE_INTEGER;
-    let minDistanceY = Number.MAX_SAFE_INTEGER;
-    thumb.service.sizes.forEach((size, index) => {
-      if (pWidth) {
-        const xDistance = Math.abs(size.width - pWidth);
-        if (minDistanceX >= xDistance) {
-          closestSizeIndex = index;
-          minDistanceX = xDistance;
-        }
-      }
-      if (pHeight) {
-        const yDistance = Math.abs(size.height - pHeight);
-        if (minDistanceY >= yDistance) {
-          closestSizeIndex = index;
-          minDistanceY = yDistance;
-        }
-      }
-    });
-    const thumbUrlParts = (thumb.id || thumb['@id']).split('/');
-    if (closestSizeIndex !== -1) {
-      const size = thumb.service.sizes[closestSizeIndex];
-      thumbUrlParts[thumbUrlParts.length - 3] = [size.width, size.height].join(',');
-    }
-    return thumbUrlParts.join('/');
-  }
-    return (thumb.id || thumb['@id']);
-};
-
 
 class ManifestCabinet extends React.Component {
   thumbnailCache = {};

--- a/src/components/ManifestCabinet/ManifestCabinet.scss
+++ b/src/components/ManifestCabinet/ManifestCabinet.scss
@@ -8,18 +8,42 @@
     width: 100%;
     height: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
   }
   &__thumb-list {
     display: flex;
+    align-items: flex-start;
   }
   &__thumb {
-    height: 100%;
     margin: 0px 8px;
-    object-fit: cover;
     box-sizing: border-box;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    transform: scale(1.0);
+    transition: transform 0.15s ease-out;
+    
     &--selected {
       //border: 8px solid white;
       //margin: 0;
+      transform: scale(1.1);
+      transition: transform 0.15s ease-out;
     }
+  }
+  &__thumb-img {
+    object-fit: cover;
+    height: 100%;
+    width: 100%;
+    outline: 0;
+  }
+  &__thumb-missing {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    background: black;
+    color: white;
+    vertical-align: middle;
   }
 }

--- a/src/components/Menu/menu.js
+++ b/src/components/Menu/menu.js
@@ -1,26 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate } from 'react-translate';
 import { Link } from 'gatsby';
 import './menu.css';
 
-const Menu = ({ style, language }) => (
+const Menu = ({ t, style, language }) => (
   <nav style={style} className="main-menu">
     <ul className="main-menu__list">
-      <li className="main-menu__list-item"><Link to={`/${language}/exhibitions/`} className="main-menu__link">Exhibitions</Link></li>
-      <li className="main-menu__list-item"><Link to={`/${language}/collections/`} className="main-menu__link">Collections</Link></li>
-      <li className="main-menu__list-item"><Link to={`/${language}/publications/`} className="main-menu__link">Publications</Link></li>
-      <li className="main-menu__list-item"><Link to={`/${language}/about/`} className="main-menu__link">About</Link></li>
+      <li className="main-menu__list-item"><Link to={`/${language}/exhibitions/`} className="main-menu__link">{t('EXHIBITIONS')}</Link></li>
+      <li className="main-menu__list-item"><Link to={`/${language}/collections/`} className="main-menu__link">{t('COLLECTIONS')}</Link></li>
+      <li className="main-menu__list-item"><Link to={`/${language}/publications/`} className="main-menu__link">{t('PUBLICATIONS')}</Link></li>
+      <li className="main-menu__list-item"><Link to={`/${language}/about/`} className="main-menu__link">{t('ABOUT')}</Link></li>
     </ul>
   </nav>
 );
 
 Menu.propTypes = {
+  t: PropTypes.func,
   style: PropTypes.object,
   language: PropTypes.string.isRequired,
 };
 
 Menu.defaultProps = {
   style: {},
+  t: key => key,
 };
 
-export default Menu;
+export default translate('Menu')(Menu);

--- a/src/components/delft-styles.scss
+++ b/src/components/delft-styles.scss
@@ -334,13 +334,16 @@ a {
 	color: inherit;
 	text-decoration: none;
 	border-bottom: 0.1em solid;
-	text-transform: uppercase;
+  text-transform: uppercase;
 }
 
-
-
-
-
+button.readmore {
+  color: #fff;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+}
 
 //grid based on fixed px dimensions 12 columns wide
 @media #{$medium-up} {
@@ -464,10 +467,12 @@ main {
 				&.column {
 					display: flex;
 					flex-flow: column;
-				}
+        }
+        button.readmore,
 				a.readmore {
 					display: inline-block;
-					margin-top:1rem;
+          margin-top:1rem;
+
 				}
 			}			
 		}

--- a/src/exhibitions/rise-of-a-campus.json
+++ b/src/exhibitions/rise-of-a-campus.json
@@ -7,14 +7,6 @@
         "Tentoonstelling manifest"
       ]
     },
-    "summary": {
-      "en": [
-        "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
-      ],
-      "nl": [
-        "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
-      ]
-    },
     "type": "Manifest",
     "id": "http://digirati.com/iiif/v3/temporary/manifest",
     "items": [
@@ -78,7 +70,23 @@
           "height": 1024,
           "width": 1006
         }],
-        "behavior": ["w-4", "h-4"]
+        "behavior": ["w-8", "h-8"]
+      },
+      {
+        "type": "Canvas",
+        "width": 1000,
+        "height": 1000,
+        "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0",
+        "summary": {
+          "en": [
+            "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+          ],
+          "nl": [
+            "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+          ]
+        },
+        "items": [],
+        "behavior": ["w-4", "h-4", "info"]
       },
       {
         "label": {

--- a/src/exhibitions/rise-of-a-campus.json
+++ b/src/exhibitions/rise-of-a-campus.json
@@ -8,7 +8,7 @@
       ]
     },
     "type": "Manifest",
-    "id": "http://digirati.com/iiif/v3/temporary/manifest",
+    "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus",
     "items": [
       {
         "label": {
@@ -22,13 +22,13 @@
         "height": 1669,
         "width": 1640,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -50,10 +50,10 @@
                   "height": 1669,
                   "width": 1640
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-1/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/list/c1-ap1"
           }
         ],
         "thumbnail":[{
@@ -76,7 +76,7 @@
         "type": "Canvas",
         "width": 1000,
         "height": 1000,
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c0",
         "summary": {
           "en": [
             "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
@@ -110,13 +110,13 @@
         "height": 1628,
         "width": 1625,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-3/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-3/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -138,10 +138,10 @@
                   "height": 1628,
                   "width": 1625
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-3/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/list/c1-ap1"
           }
         ],
         "thumbnail": [{
@@ -174,13 +174,13 @@
         "height": 2037,
         "width": 2048,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-2/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -202,10 +202,10 @@
                   "height": 2037,
                   "width": 2048
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-2/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/list/c1-ap1"
           }
         ],
         "thumbnail": [{
@@ -238,13 +238,13 @@
         "height": 1495,
         "width": 1997,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-4/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-4/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -266,10 +266,10 @@
                   "height": 1495,
                   "width": 1997
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-4/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-4/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/rise-of-a-campus/list/c1-ap1"
           }
         ],
         "thumbnail": [{

--- a/src/exhibitions/test.json
+++ b/src/exhibitions/test.json
@@ -1,18 +1,10 @@
 {
     "label": {
       "en": [
-        "Rise of a Campus"
+        "Rise of a Campus [test every structure]"
       ],
       "nl": [
-        "Tentoonstelling manifest"
-      ]
-    },
-    "summary": {
-      "en": [
-        "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
-      ],
-      "nl": [
-        "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+        "Tentoonstelling manifest [test elke structuur]"
       ]
     },
     "type": "Manifest",
@@ -83,7 +75,88 @@
           "height": 1024,
           "width": 1006
         }],
-        "behavior": ["w-4", "h-4"]
+        "behavior": ["w-8", "h-8"]
+      },
+      {
+        "type": "Canvas",
+        "width": 1000,
+        "height": 1000,
+        "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0",
+        "summary": {
+          "en": [
+            "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+          ],
+          "nl": [
+            "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+          ]
+        },
+        "items": [
+          {
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c0-1",
+                "type": "Annotation",
+                "motivation": "painting",
+                "label": {
+                  "en": [
+                    "Title"
+                  ],
+                  "nl": [
+                    "[NL]Title"
+                  ]
+                },
+                "summary": {
+                  "en": [
+                    "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+                  ],
+                  "nl": [
+                    "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+                  ]
+                },
+                "body": {
+                  "type": "TextualBody",
+                  "format": "text/html",
+                  "value": "null",
+                  "height": 1669,
+                  "width": 1640
+                },
+                "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0"
+              },
+              {
+                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c0-1",
+                "type": "Annotation",
+                "motivation": "painting",
+                "label": {
+                  "en": [
+                    "Title 2"
+                  ],
+                  "nl": [
+                    "[NL]Title 2"
+                  ]
+                },
+                "summary": {
+                  "en": [
+                    "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+                  ],
+                  "nl": [
+                    "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
+                  ]
+                },
+                "body": {
+                  "type": "TextualBody",
+                  "format": "text/html",
+                  "value": "null",
+                  "height": 1669,
+                  "width": 1640
+                },
+                "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0"
+              }
+            ],
+            "id": "https://delft-static-site-generator.netlify.com/objects/object-1/list/c0-ap1"
+          }
+        ],
+        "behavior": ["w-4", "h-4", "info"]
       },
       {
         "label": {

--- a/src/exhibitions/test.json
+++ b/src/exhibitions/test.json
@@ -124,7 +124,7 @@
                 "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0"
               },
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c0-1",
+                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c0-2",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {

--- a/src/exhibitions/test.json
+++ b/src/exhibitions/test.json
@@ -8,7 +8,7 @@
       ]
     },
     "type": "Manifest",
-    "id": "http://digirati.com/iiif/v3/temporary/manifest",
+    "id": "https://delft-static-site-generator.netlify.com/exhibitions/test",
     "items": [
       {
         "label": {
@@ -22,13 +22,13 @@
         "height": 1669,
         "width": 1640,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -55,10 +55,10 @@
                   "height": 1669,
                   "width": 1640
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-1/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/list/c1-ap1"
           }
         ],
         "thumbnail":[{
@@ -81,7 +81,7 @@
         "type": "Canvas",
         "width": 1000,
         "height": 1000,
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c0",
         "summary": {
           "en": [
             "A campus is a living thing. It expands and shrinks. It follows the changing needs of the university. It can be perceived as lively yet it can be boring. In an ideal situation, knowledge garnered from the most exotic branches of research wafts through the air. Some see the campus as the epitome of the grandeur of a university, others see it as an industrial area. Just like any other neighbourhood, it has a distinct style and atmosphere."
@@ -95,7 +95,7 @@
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c0-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/annot/c0-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -121,10 +121,10 @@
                   "height": 1669,
                   "width": 1640
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c0"
               },
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c0-2",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/annot/c0-2",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -150,10 +150,10 @@
                   "height": 1669,
                   "width": 1640
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c0"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c0"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-1/list/c0-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/list/c0-ap1"
           }
         ],
         "behavior": ["w-4", "h-4", "info"]
@@ -180,13 +180,13 @@
         "height": 1628,
         "width": 1625,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-3/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-3/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -213,10 +213,10 @@
                   "height": 1628,
                   "width": 1625
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-3/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/list/c1-ap1"
           }
         ],
         "thumbnail": [{
@@ -249,13 +249,13 @@
         "height": 2037,
         "width": 2048,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-2/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -282,10 +282,10 @@
                   "height": 2037,
                   "width": 2048
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-2/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/list/c1-ap1"
           }
         ],
         "thumbnail": [{
@@ -318,13 +318,13 @@
         "height": 1495,
         "width": 1997,
         "type": "Canvas",
-        "id": "https://delft-static-site-generator.netlify.com/objects/object-4/canvas/c1",
+        "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1",
         "items": [
           {
             "type": "AnnotationPage",
             "items": [
               {
-                "id": "https://delft-static-site-generator.netlify.com/objects/object-4/annot/c1-1",
+                "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/annot/c1-1",
                 "type": "Annotation",
                 "motivation": "painting",
                 "label": {
@@ -346,10 +346,10 @@
                   "height": 1495,
                   "width": 1997
                 },
-                "target": "https://delft-static-site-generator.netlify.com/objects/object-4/canvas/c1"
+                "target": "https://delft-static-site-generator.netlify.com/exhibitions/test/canvas/c1"
               }
             ],
-            "id": "https://delft-static-site-generator.netlify.com/objects/object-4/list/c1-ap1"
+            "id": "https://delft-static-site-generator.netlify.com/exhibitions/test/list/c1-ap1"
           }
         ],
         "thumbnail": [{

--- a/src/objects/multi-canvas-object.json
+++ b/src/objects/multi-canvas-object.json
@@ -1,252 +1,800 @@
 {
+  "@context": [
+    "http://www.w3.org/ns/anno.jsonld",
+    "http://iiif.io/api/presentation/3/context.json"
+  ],
+  "type": "Manifest",
   "label": {
     "en": [
-      "First test object"
+      "Multi canvas object"
+    ],
+    "nl": [
+      "Meerdere canvas objecten"
     ]
   },
-  "summary": {
-    "en": [
-      "This is some new content"
-    ]
-  },
-  "type": "Manifest",
-  "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object",
+  "metadata": [
+		{
+			"label": {
+        "en": [ "Title" ],
+        "nl": [ "Titel" ]
+      },
+			"value": {
+        "en": ["Forth Bridge illustrations 1886-1887"],
+        "nl": [" - "]
+      }
+		},
+		{
+      "label": {
+        "en": [ "Description" ],
+        "nl": [ "Omschrijving" ]
+      },
+			"value": {
+        "en": ["40 black-and-white photographs capturing the construction of the Forth Bridge by Glasgow-based Sir William Arrol & Co. Close-up and distance views of superstructure, cantilevers, lifting platforms and viaduct. Taken at weekly or fortnightly intervals from 1886-1887 by Philip Phillips, son of one of the contractors. Silver gelatin prints."],
+        "nl": [" - "]
+      }
+    },
+		{
+      "label": {
+        "en": [ "Part reference" ],
+        "nl": ["Onderdeel Referentie"]
+      },
+			"value": {
+        "en": [""],
+        "nl": [""]
+      }
+		},
+		{
+      "label": {
+        "en": [ "Shelfmark" ],
+        "nl": [ "Shelfmark ???" ]
+      },
+			"value": {
+        "en": ["RB.l.229"],
+        "nl": ["RB.l.229"]
+      }
+		},
+		{
+      "label": {
+        "en": [ "" ],
+        "nl": [ "" ]
+      },
+			"value": {
+        "en": ["<a href=\"http://digital.nls.uk/74464117\">View in our digital gallery</a>"],
+        "nl": ["<a href=\"http://digital.nls.uk/74464117\">Bekijk in onze digitale galerij</a>"]
+      }
+		},
+		{
+      "label": {
+        "en": [ "Full conditions of use" ]
+      },
+			"value": {
+        "en": ["You have permission to use this work under the <a target=\"_top\" href=\"https://creativecommons.org/licenses/by-nc-sa/4.0/\">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Licence</a> unless otherwise stated."]
+      }
+		}
+	],
   "items": [
     {
       "label": {
         "en": [
-          "Canvas 1"
+          "1st Canvas"
+        ],
+        "nl": [
+          "eerst canvas"
+        ]
+      },
+      "height": 671,
+      "width": 1191,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/5/1/08256e88-fa03-4c0e-905e-92ceed23f6b3/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 671,
+                "width": 1191,
+                "label": {
+                  "en": [
+                    "-"
+                  ]
+                },
+                "service": {
+                  "type": "ImageService2",
+                  "id": "https://dlc.services/iiif-img/5/1/08256e88-fa03-4c0e-905e-92ceed23f6b3",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 1191,
+                  "height": 671,
+                  "tiles": [
+                    {
+                      "width": 256,
+                      "height": 256,
+                      "scaleFactors": [
+                        1,
+                        2,
+                        4,
+                        8
+                      ]
+                    }
+                  ],
+                  "sizes": [
+                    {
+                      "width": 1024,
+                      "height": 577
+                    },
+                    {
+                      "width": 400,
+                      "height": 225
+                    },
+                    {
+                      "width": 200,
+                      "height": 113
+                    },
+                    {
+                      "width": 100,
+                      "height": 56
+                    }
+                  ],
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/5/1/08256e88-fa03-4c0e-905e-92ceed23f6b3/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/5/1/08256e88-fa03-4c0e-905e-92ceed23f6b3",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 577,
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 577
+                      },
+                      {
+                        "width": 400,
+                        "height": 225
+                      },
+                      {
+                        "width": 200,
+                        "height": 113
+                      },
+                      {
+                        "width": 100,
+                        "height": 56
+                      }
+                    ],
+                    "protocol": "http://iiif.io/api/image"
+                  }
+                }
+              ],
+              "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/annotation/ff0d1326-175d-3d13-7e3e-3515db5445c0",
+              "target": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/884fc9ee-08f8-1be3-e4ac-c2afb2fa1b4e"
+            }
+          ],
+          "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/list/7dacf072-8bfd-aa89-e597-e5669b4f2ad1"
+        }
+      ],
+      "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/884fc9ee-08f8-1be3-e4ac-c2afb2fa1b4e"
+    },
+    {
+      "label": {
+        "en": [
+          "2nd Canvas"
+        ],
+        "nl": [
+          "tweede canvas"
         ]
       },
       "height": 1669,
       "width": 1640,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c1",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c1-1",
-              "type": "Annotation",
               "motivation": "painting",
-              "label": {
-                "en": [
-                  "Image Annotation 1"
-                ]
-              },
+              "type": "Annotation",
               "body": {
-                "id": "https://dlc.services/iiif-img/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpgg",
+                "id": "https://dlc.services/iiif-img/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpg",
                 "type": "Image",
-                "format": "image/jpg",
-                "service": [
-                  {
-                    "id": "https://dlc.services/iiif-img/5/1/2378e17e-F976-419f-92f7-Cb3bb883e009",
-                    "type": "ImageService3",
-                    "profile": "level2"
-                  }
-                ],
+                "format": "image/jpeg",
                 "height": 1669,
-                "width": 1640
+                "width": 1640,
+                "label": {
+                  "en": [
+                    "-"
+                  ]
+                },
+                "service": {
+                  "type": "ImageService2",
+                  "id": "https://dlc.services/iiif-img/5/1/2378e17e-f976-419f-92f7-cb3bb883e009",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 1640,
+                  "height": 1669,
+                  "tiles": [
+                    {
+                      "width": 256,
+                      "height": 256,
+                      "scaleFactors": [
+                        1,
+                        2,
+                        4,
+                        8
+                      ]
+                    }
+                  ],
+                  "sizes": [
+                    {
+                      "width": 1006,
+                      "height": 1024
+                    },
+                    {
+                      "width": 393,
+                      "height": 400
+                    },
+                    {
+                      "width": 197,
+                      "height": 200
+                    },
+                    {
+                      "width": 98,
+                      "height": 100
+                    }
+                  ],
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                }
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c1"
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1006,
+                    "height": 1024,
+                    "sizes": [
+                      {
+                        "width": 1006,
+                        "height": 1024
+                      },
+                      {
+                        "width": 393,
+                        "height": 400
+                      },
+                      {
+                        "width": 197,
+                        "height": 200
+                      },
+                      {
+                        "width": 98,
+                        "height": 100
+                      }
+                    ],
+                    "protocol": "http://iiif.io/api/image"
+                  }
+                }
+              ],
+              "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/annotation/1c011313-3b63-f933-aaa4-c4abcb513438",
+              "target": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/77689e9f-4ef2-6412-4455-5d611f84824e"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c1-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/list/48ffed49-977a-9e0e-5f2f-e79f6585aa4b"
         }
       ],
-      "thumbnail":[{
-        "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpg",
-        "type": "Image",
-        "format": "image/jpg",
-        "service": [
-          {
-            "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009",
-            "type": "ImageService3",
-            "profile": "level2"
-          }
-        ],
-        "height": 1024,
-        "width": 1006
-      }]
+      "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/77689e9f-4ef2-6412-4455-5d611f84824e"
     },
     {
       "label": {
         "en": [
-          "Canvas 2"
+          "3rd Canvas"
+        ],
+        "nl": [
+          "derde canvas"
         ]
       },
       "height": 2037,
       "width": 2048,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c2",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c2-1",
-              "type": "Annotation",
               "motivation": "painting",
-              "label": {
-                "en": [
-                  "Image Annotation 1"
-                ]
-              },
-              "body": {
-                "id": "https://dlc.services/iiif-img/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg",
-                "type": "Image",
-                "format": "image/jpg",
-                "service": [
-                  {
-                    "id": "https://dlc.services/iiif-img/5/1/bb277e73-7526-4416-9b0f-07b72748f391",
-                    "type": "ImageService3",
-                    "profile": "level2"
-                  }
-                ],
-                "height": 2037,
-                "width": 2048
-              },
-              "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c2"
-            }
-          ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c2-ap1"
-        }
-      ],
-      "thumbnail": [{
-        "id": "https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg",
-        "type": "Image",
-        "format": "image/jpg",
-        "service": [
-          {
-            "id": "https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391",
-            "type": "ImageService3",
-            "profile": "level2"
-          }
-        ],
-        "height": 1018,
-        "width": 1024
-      }]
-    },
-    {
-      "label": {
-        "en": [
-          "Canvas 3"
-        ]
-      },
-      "height": 1628,
-      "width": 1625,
-      "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c3",
-      "items": [
-        {
-          "type": "AnnotationPage",
-          "items": [
-            {
-              "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c3-1",
               "type": "Annotation",
-              "motivation": "painting",
-              "label": {
-                "en": [
-                  "Image Annotation 1"
-                ]
-              },
               "body": {
                 "id": "https://dlc.services/iiif-img/5/1/3115675e-1f06-4b85-8670-fb05593c4b36/full/full/0/default.jpg",
                 "type": "Image",
-                "format": "image/jpg",
-                "service": [
-                  {
-                    "id": "https://dlc.services/iiif-img/5/1/3115675e-1f06-4b85-8670-fb05593c4b36",
-                    "type": "ImageService3",
-                    "profile": "level2"
-                  }
-                ],
-                "height": 1628,
-                "width": 1625
+                "format": "image/jpeg",
+                "height": 2037,
+                "width": 2048,
+                "label": {
+                  "en": [
+                    "-"
+                  ]
+                },
+                "service": {
+                  "type": "ImageService2",
+                  "id": "https://dlc.services/iiif-img/5/1/3115675e-1f06-4b85-8670-fb05593c4b36",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 2048,
+                  "height": 2037,
+                  "tiles": [
+                    {
+                      "width": 256,
+                      "height": 256,
+                      "scaleFactors": [
+                        1,
+                        2,
+                        4,
+                        8
+                      ]
+                    }
+                  ],
+                  "sizes": [
+                    {
+                      "width": 1024,
+                      "height": 1018
+                    },
+                    {
+                      "width": 400,
+                      "height": 398
+                    },
+                    {
+                      "width": 200,
+                      "height": 199
+                    },
+                    {
+                      "width": 100,
+                      "height": 99
+                    }
+                  ],
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                }
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c3"
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/5/1/3115675e-1f06-4b85-8670-fb05593c4b36/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/5/1/3115675e-1f06-4b85-8670-fb05593c4b36",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 1018,
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 1018
+                      },
+                      {
+                        "width": 400,
+                        "height": 398
+                      },
+                      {
+                        "width": 200,
+                        "height": 199
+                      },
+                      {
+                        "width": 100,
+                        "height": 99
+                      }
+                    ],
+                    "protocol": "http://iiif.io/api/image"
+                  }
+                }
+              ],
+              "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/annotation/a50b700f-7c81-3112-3689-5a7e7037df34",
+              "target": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/fbf3301d-cb4e-0e6c-f9c2-02d7445011b5"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c3-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/list/6c320017-7d6d-189d-cdec-13287c571a06"
         }
       ],
-      "thumbnail": [{
-        "id": "https://dlc.services/thumbs/5/1/3115675e-1f06-4b85-8670-fb05593c4b36/full/1022,1024/0/default.jpg",
-        "type": "Image",
-        "format": "image/jpg",
-        "service": [
-          {
-            "id": "https://dlc.services/thumbs/5/1/3115675e-1f06-4b85-8670-fb05593c4b36",
-            "type": "ImageService3",
-            "profile": "level2"
-          }
-        ],
-        "height": 1024,
-        "width": 1022
-      }]
+      "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/fbf3301d-cb4e-0e6c-f9c2-02d7445011b5"
     },
     {
       "label": {
         "en": [
-          "Canvas 4"
+          "4th Canvas"
+        ],
+        "nl": [
+          "vierde doek"
         ]
       },
-      "height": 1495,
-      "width": 1997,
+      "height": 1876,
+      "width": 2263,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c4",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c4-1",
-              "type": "Annotation",
               "motivation": "painting",
-              "label": {
-                "en": [
-                  "Image Annotation 1"
-                ]
-              },
+              "type": "Annotation",
               "body": {
-                "id": "https://dlc.services/iiif-img/5/1/73465289-f503-4850-be04-15ae8264819c/full/full/0/default.jpg",
+                "id": "https://dlc.services/iiif-img/5/1/43860efa-3b7d-4954-a234-9b7d438621b5/full/full/0/default.jpg",
                 "type": "Image",
-                "format": "image/jpg",
-                "service": [
-                  {
-                    "id": "https://dlc.services/iiif-img/5/1/73465289-f503-4850-be04-15ae8264819c",
-                    "type": "ImageService3",
-                    "profile": "level2"
-                  }
-                ],
-                "height": 1495,
-                "width": 1997
+                "format": "image/jpeg",
+                "height": 1876,
+                "width": 2263,
+                "label": {
+                  "en": [
+                    "-"
+                  ]
+                },
+                "service": {
+                  "type": "ImageService2",
+                  "id": "https://dlc.services/iiif-img/5/1/43860efa-3b7d-4954-a234-9b7d438621b5",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 2263,
+                  "height": 1876,
+                  "tiles": [
+                    {
+                      "width": 256,
+                      "height": 256,
+                      "scaleFactors": [
+                        1,
+                        2,
+                        4,
+                        8,
+                        16
+                      ]
+                    }
+                  ],
+                  "sizes": [
+                    {
+                      "width": 1024,
+                      "height": 849
+                    },
+                    {
+                      "width": 400,
+                      "height": 332
+                    },
+                    {
+                      "width": 200,
+                      "height": 166
+                    },
+                    {
+                      "width": 100,
+                      "height": 83
+                    }
+                  ],
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                }
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c4"
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/5/1/43860efa-3b7d-4954-a234-9b7d438621b5/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/5/1/43860efa-3b7d-4954-a234-9b7d438621b5",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 849,
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 849
+                      },
+                      {
+                        "width": 400,
+                        "height": 332
+                      },
+                      {
+                        "width": 200,
+                        "height": 166
+                      },
+                      {
+                        "width": 100,
+                        "height": 83
+                      }
+                    ],
+                    "protocol": "http://iiif.io/api/image"
+                  }
+                }
+              ],
+              "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/annotation/544dd627-a5d3-f15a-18fb-10cad758eb55",
+              "target": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/94607bca-0d09-c68f-732b-9348f8e21d2d"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c4-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/list/1e756191-98b1-6e26-236e-8df9c476a7fb"
         }
       ],
-      "thumbnail": [{
-        "id": "https://dlc.services/thumbs/5/1/73465289-f503-4850-be04-15ae8264819c/full/full/0/default.jpg",
-        "type": "Image",
-        "format": "image/jpg",
-        "service": [
-          {
-            "id": "https://dlc.services/thumbs/5/1/73465289-f503-4850-be04-15ae8264819c",
-            "type": "ImageService3",
-            "profile": "level2"
-          }
+      "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/94607bca-0d09-c68f-732b-9348f8e21d2d"
+    },
+    {
+      "label": {
+        "en": [
+          "Fifth canvas"
         ],
-        "height": 767,
-        "width": 1024
-      }]
+        "nl": [
+          "vijfde canvas"
+        ]
+      },
+      "height": 2551,
+      "width": 3916,
+      "type": "Canvas",
+      "items": [
+        {
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "motivation": "painting",
+              "type": "Annotation",
+              "body": {
+                "id": "https://dlc.services/iiif-img/5/1/515e9162-9c17-4bc5-8a79-9fb6f59c44c5/full/full/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2551,
+                "width": 3916,
+                "label": {
+                  "en": [
+                    "-"
+                  ]
+                },
+                "service": {
+                  "type": "ImageService2",
+                  "id": "https://dlc.services/iiif-img/5/1/515e9162-9c17-4bc5-8a79-9fb6f59c44c5",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 3916,
+                  "height": 2551,
+                  "tiles": [
+                    {
+                      "width": 256,
+                      "height": 256,
+                      "scaleFactors": [
+                        1,
+                        2,
+                        4,
+                        8,
+                        16
+                      ]
+                    }
+                  ],
+                  "sizes": [
+                    {
+                      "width": 1024,
+                      "height": 667
+                    },
+                    {
+                      "width": 400,
+                      "height": 261
+                    },
+                    {
+                      "width": 200,
+                      "height": 130
+                    },
+                    {
+                      "width": 100,
+                      "height": 65
+                    }
+                  ],
+                  "profile": [
+                    "http://iiif.io/api/image/2/level1.json",
+                    {
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
+                      "supports": [
+                        "regionByPct",
+                        "sizeByForcedWh",
+                        "sizeByWh",
+                        "sizeAboveFull",
+                        "rotationBy90s",
+                        "mirroring",
+                        "gray"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "thumbnail": [
+                {
+                  "id": "https://dlc.services/thumbs/5/1/515e9162-9c17-4bc5-8a79-9fb6f59c44c5/full/full/0/default.jpg",
+                  "type": "Image",
+                  "service": {
+                    "type": "ImageService2",
+                    "id": "https://dlc.services/thumbs/5/1/515e9162-9c17-4bc5-8a79-9fb6f59c44c5",
+                    "profile": [
+                      "http://iiif.io/api/image/2/level0.json",
+                      {
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
+                      }
+                    ],
+                    "width": 1024,
+                    "height": 667,
+                    "sizes": [
+                      {
+                        "width": 1024,
+                        "height": 667
+                      },
+                      {
+                        "width": 400,
+                        "height": 261
+                      },
+                      {
+                        "width": 200,
+                        "height": 130
+                      },
+                      {
+                        "width": 100,
+                        "height": 65
+                      }
+                    ],
+                    "protocol": "http://iiif.io/api/image"
+                  }
+                }
+              ],
+              "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/annotation/7a80efa4-17c8-a58b-0be9-15ec3a77e886",
+              "target": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/95204d48-eed3-8a29-dff1-fc7eda57a09a"
+            }
+          ],
+          "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/list/259cc037-92ef-603c-09d8-4cab18dc4938"
+        }
+      ],
+      "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/95204d48-eed3-8a29-dff1-fc7eda57a09a"
     }
   ],
-  "@context": [
-    "http://www.w3.org/ns/anno.jsonld",
-    "http://iiif.io/api/presentation/3/context.json"
-  ]
+  "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/manifest"
 }

--- a/src/objects/multi-canvas-object.json
+++ b/src/objects/multi-canvas-object.json
@@ -796,5 +796,5 @@
       "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/canvas/95204d48-eed3-8a29-dff1-fc7eda57a09a"
     }
   ],
-  "id": "https://delft-static-site-generator.netlify.com/iiif/18fe5949-601f-b19f-1cde-f78f8f6caa28/manifest"
+  "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object"
 }

--- a/src/objects/multi-canvas-object.json
+++ b/src/objects/multi-canvas-object.json
@@ -4,6 +4,11 @@
       "First test object"
     ]
   },
+  "summary": {
+    "en": [
+      "This is some new content"
+    ]
+  },
   "type": "Manifest",
   "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object",
   "items": [

--- a/src/objects/object-1.json
+++ b/src/objects/object-1.json
@@ -2,6 +2,9 @@
   "label": {
     "en": [
       "First test object"
+    ],
+    "nl": [
+      "[NL]First test object"
     ]
   },
   "type": "Manifest",
@@ -11,6 +14,9 @@
       "label": {
         "en": [
           "Canvas 1"
+        ],
+        "nl": [
+          "[NL]Canvas 1"
         ]
       },
       "height": 1669,
@@ -28,6 +34,9 @@
               "label": {
                 "en": [
                   "Image Annotation 1"
+                ],
+                "nl": [
+                  "[NL]Image Annotation 1"
                 ]
               },
               "body": {
@@ -36,7 +45,7 @@
                 "format": "image/jpg",
                 "service": [
                   {
-                    "id": "https://dlc.services/iiif-img/5/1/2378e17e-f976-419f-92f7-Cb3bb883e009",
+                    "id": "https://dlc.services/iiif-img/5/1/2378e17e-f976-419f-92f7-cb3bb883e009",
                     "type": "ImageService3",
                     "profile": "level2"
                   }

--- a/src/objects/second-multi-canvas-object.json
+++ b/src/objects/second-multi-canvas-object.json
@@ -1,0 +1,260 @@
+{
+    "label": {
+      "en": [
+        "First test object"
+      ]
+    },
+    "summary": {
+      "en": [
+        "This is some new content"
+      ]
+    },
+    "type": "Manifest",
+    "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object-2",
+    "items": [
+      {
+        "label": {
+          "en": [
+            "Canvas 1"
+          ]
+        },
+        "height": 1669,
+        "width": 1640,
+        "type": "Canvas",
+        "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object-2/canvas/c1",
+        "items": [
+          {
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object-2/annot/c1-1",
+                "type": "Annotation",
+                "motivation": "painting",
+                "label": {
+                  "en": [
+                    "Image Annotation 1"
+                  ]
+                },
+                "body": {
+                  "id": "https://dlc.services/iiif-img/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpgg",
+                  "type": "Image",
+                  "format": "image/jpg",
+                  "service": [
+                    {
+                      "id": "https://dlc.services/iiif-img/5/1/2378e17e-F976-419f-92f7-Cb3bb883e009",
+                      "type": "ImageService3",
+                      "profile": "level2"
+                    }
+                  ],
+                  "height": 1669,
+                  "width": 1640
+                },
+                "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object-2/canvas/c1"
+              }
+            ],
+            "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object-2/list/c1-ap1"
+          }
+        ],
+        "thumbnail": [
+          {
+            "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009/full/full/0/default.jpg",
+            "type": "Image",
+            "format": "image/jpg",
+            "service": [
+              {
+                "id": "https://dlc.services/thumbs/5/1/2378e17e-f976-419f-92f7-cb3bb883e009",
+                "type": "ImageService3",
+                "profile": "level2"
+              }
+            ],
+            "height": 1024,
+            "width": 1006
+          }
+        ]
+      },
+      {
+        "label": {
+          "en": [
+            "Canvas 2"
+          ]
+        },
+        "height": 2037,
+        "width": 2048,
+        "type": "Canvas",
+        "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c2",
+        "items": [
+          {
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c2-1",
+                "type": "Annotation",
+                "motivation": "painting",
+                "label": {
+                  "en": [
+                    "Image Annotation 1"
+                  ]
+                },
+                "body": {
+                  "id": "https://dlc.services/iiif-img/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpg",
+                  "service": [
+                    {
+                      "id": "https://dlc.services/iiif-img/5/1/bb277e73-7526-4416-9b0f-07b72748f391",
+                      "type": "ImageService3",
+                      "profile": "level2"
+                    }
+                  ],
+                  "height": 2037,
+                  "width": 2048
+                },
+                "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c2"
+              }
+            ],
+            "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c2-ap1"
+          }
+        ],
+        "thumbnail": [
+          {
+            "id": "https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391/full/full/0/default.jpg",
+            "type": "Image",
+            "format": "image/jpg",
+            "service": [
+              {
+                "id": "https://dlc.services/thumbs/5/1/bb277e73-7526-4416-9b0f-07b72748f391",
+                "type": "ImageService3",
+                "profile": "level2"
+              }
+            ],
+            "height": 1018,
+            "width": 1024
+          }
+        ]
+      },
+      {
+        "label": {
+          "en": [
+            "Canvas 3"
+          ]
+        },
+        "height": 1628,
+        "width": 1625,
+        "type": "Canvas",
+        "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c3",
+        "items": [
+          {
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c3-1",
+                "type": "Annotation",
+                "motivation": "painting",
+                "label": {
+                  "en": [
+                    "Image Annotation 1"
+                  ]
+                },
+                "body": {
+                  "id": "https://dlc.services/iiif-img/5/1/3115675e-1f06-4b85-8670-fb05593c4b36/full/full/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpg",
+                  "service": [
+                    {
+                      "id": "https://dlc.services/iiif-img/5/1/3115675e-1f06-4b85-8670-fb05593c4b36",
+                      "type": "ImageService3",
+                      "profile": "level2"
+                    }
+                  ],
+                  "height": 1628,
+                  "width": 1625
+                },
+                "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c3"
+              }
+            ],
+            "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c3-ap1"
+          }
+        ],
+        "thumbnail": [
+          {
+            "id": "https://dlc.services/thumbs/5/1/3115675e-1f06-4b85-8670-fb05593c4b36/full/1022,1024/0/default.jpg",
+            "type": "Image",
+            "format": "image/jpg",
+            "service": [
+              {
+                "id": "https://dlc.services/thumbs/5/1/3115675e-1f06-4b85-8670-fb05593c4b36",
+                "type": "ImageService3",
+                "profile": "level2"
+              }
+            ],
+            "height": 1024,
+            "width": 1022
+          }
+        ]
+      },
+      {
+        "label": {
+          "en": [
+            "Canvas 4"
+          ]
+        },
+        "height": 1495,
+        "width": 1997,
+        "type": "Canvas",
+        "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c4",
+        "items": [
+          {
+            "type": "AnnotationPage",
+            "items": [
+              {
+                "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/annot/c4-1",
+                "type": "Annotation",
+                "motivation": "painting",
+                "label": {
+                  "en": [
+                    "Image Annotation 1"
+                  ]
+                },
+                "body": {
+                  "id": "https://dlc.services/iiif-img/5/1/73465289-f503-4850-be04-15ae8264819c/full/full/0/default.jpg",
+                  "type": "Image",
+                  "format": "image/jpg",
+                  "service": [
+                    {
+                      "id": "https://dlc.services/iiif-img/5/1/73465289-f503-4850-be04-15ae8264819c",
+                      "type": "ImageService3",
+                      "profile": "level2"
+                    }
+                  ],
+                  "height": 1495,
+                  "width": 1997
+                },
+                "target": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/canvas/c4"
+              }
+            ],
+            "id": "https://delft-static-site-generator.netlify.com/objects/multi-canvas-object/list/c4-ap1"
+          }
+        ],
+        "thumbnail": [
+          {
+            "id": "https://dlc.services/thumbs/5/1/73465289-f503-4850-be04-15ae8264819c/full/full/0/default.jpg",
+            "type": "Image",
+            "format": "image/jpg",
+            "service": [
+              {
+                "id": "https://dlc.services/thumbs/5/1/73465289-f503-4850-be04-15ae8264819c",
+                "type": "ImageService3",
+                "profile": "level2"
+              }
+            ],
+            "height": 767,
+            "width": 1024
+          }
+        ]
+      }
+    ],
+    "@context": [
+      "http://www.w3.org/ns/anno.jsonld",
+      "http://iiif.io/api/presentation/3/context.json"
+    ]
+  }

--- a/src/objects/tentoonstelling-manifest.json
+++ b/src/objects/tentoonstelling-manifest.json
@@ -16,7 +16,7 @@
     ]
   },
   "type": "Manifest",
-  "id": "http://digirati.com/iiif/v3/temporary/manifest",
+  "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest",
   "items": [
     {
       "label": {
@@ -30,13 +30,13 @@
       "height": 1669,
       "width": 1640,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c1",
+      "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/object-1/annot/c1-1",
+              "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/annot/c1-1",
               "type": "Annotation",
               "motivation": "painting",
               "label": {
@@ -58,10 +58,10 @@
                 "height": 1669,
                 "width": 1640
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/object-1/canvas/c1"
+              "target": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/object-1/list/c1-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/list/c1-ap1"
         }
       ],
       "thumbnail": [
@@ -102,13 +102,13 @@
       "height": 2037,
       "width": 2048,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1",
+      "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/object-2/annot/c1-1",
+              "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/annot/c1-1",
               "type": "Annotation",
               "motivation": "painting",
               "label": {
@@ -130,10 +130,10 @@
                 "height": 2037,
                 "width": 2048
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1"
+              "target": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/object-2/list/c1-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/list/c1-ap1"
         }
       ],
       "thumbnail": [
@@ -172,13 +172,13 @@
       "height": 1495,
       "width": 1997,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/object-4/canvas/c1",
+      "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/object-4/annot/c1-1",
+              "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/annot/c1-1",
               "type": "Annotation",
               "motivation": "painting",
               "label": {
@@ -200,10 +200,10 @@
                 "height": 1495,
                 "width": 1997
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/object-4/canvas/c1"
+              "target": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/object-4/list/c1-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/list/c1-ap1"
         }
       ],
       "thumbnail": [
@@ -255,13 +255,13 @@
       "height": 1628,
       "width": 1625,
       "type": "Canvas",
-      "id": "https://delft-static-site-generator.netlify.com/objects/object-3/canvas/c1",
+      "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1",
       "items": [
         {
           "type": "AnnotationPage",
           "items": [
             {
-              "id": "https://delft-static-site-generator.netlify.com/objects/object-3/annot/c1-1",
+              "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/annot/c1-1",
               "type": "Annotation",
               "motivation": "painting",
               "label": {
@@ -283,10 +283,10 @@
                 "height": 1628,
                 "width": 1625
               },
-              "target": "https://delft-static-site-generator.netlify.com/objects/object-2/canvas/c1"
+              "target": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/canvas/c1"
             }
           ],
-          "id": "https://delft-static-site-generator.netlify.com/objects/object-3/list/c1-ap1"
+          "id": "https://delft-static-site-generator.netlify.com/objects/tentoonstelling-manifest/list/c1-ap1"
         }
       ],
       "thumbnail": [

--- a/src/pages/Collection/Collection.js
+++ b/src/pages/Collection/Collection.js
@@ -57,7 +57,7 @@ const CollectionPage = ({ pageContext, '*': path }) => {
             {
             items.map(
               manifest => (
-                <div className="w-4 h-6 block--align-right">
+                <div key={`collection__${objectLinks[manifest.id || manifest['@id']]}`} className="w-4 h-6 block--align-right">
                   <div className="block w-3 h-6">
                     <div className="block image cutcorners w-3 h-3">
                       <img src={getThumbnailImageSource(manifest.thumbnail)} className="object-link__image" alt="" />

--- a/src/pages/Exhibition/Exhibition.js
+++ b/src/pages/Exhibition/Exhibition.js
@@ -220,26 +220,19 @@ class ExhibitionPage extends React.Component {
               </div>
               <div />
             </div>
-            {manifest.items && manifest.items.length > 0 && (
-              <div className="block cutcorners w-8 h-8 image">
-                {this.renderMediaHolder(
-                  manifest.items[0],
-                  this.renderCanvasBody(manifest.items[0]),
-                )}
-                <div className="caption">{manifest.items[0].label && translate(manifest.items[0].label, pageLanguage)}</div>
-              </div>
-            )}
-            <div className="block info cutcorners w-4 h-4">
-              <div className="boxtitle">ABOUT</div>
-              <div className="text">
-                { translate(manifest.summary, pageLanguage, '\n')
-                    .split('\n')
-                    .map(paragraph => <p key={`about__${paragraph}`}>{paragraph}</p>)}
-                <p><a className="readmore" href="/#">Read More</a></p>
-              </div>
-            </div>
+
             {manifest && manifest.items && manifest.items.map(
-              (canvas, index) => (index === 0 ? '' : (
+              canvas => ((canvas.behavior || []).indexOf('info') !== -1 ? (
+                <div className={this.getBlockClasses(canvas)}>
+                  <div className="boxtitle">{translate(canvas.label || { en: ['About'], nl: ['Over'] }, pageLanguage, '\n').toUpperCase()}</div>
+                  <div className="text">
+                    { translate(canvas.summary, pageLanguage, '\n')
+                        .split('\n')
+                        .map(paragraph => <p key={`about__${paragraph}`}>{paragraph}</p>)}
+                    <p><a className="readmore" onClick={this.showCanvasDetails(canvas)}>Read More</a></p>
+                  </div>
+                </div>
+              ) : (
                 <div
                   key={`manifest_item_${canvas.id}`}
                   className={this.getBlockClasses(canvas)}

--- a/src/pages/Exhibition/Exhibition.js
+++ b/src/pages/Exhibition/Exhibition.js
@@ -57,7 +57,7 @@ class ExhibitionPage extends React.Component {
     };
   }
 
-  showCanvasDetails = canvas => () => {
+  showCanvasDetails = (canvas, annotationDetails) => () => {
     const { pageContext: manifest, '*': path } = this.props;
     const pageLanguage = getPageLanguage(path);
     this.setState({
@@ -67,6 +67,7 @@ class ExhibitionPage extends React.Component {
           manifest={manifest}
           hideCanvasDetails={this.hideCanvasDetails}
           pageLanguage={pageLanguage}
+          annotationDetails={annotationDetails}
         />
       ),
     });
@@ -134,7 +135,7 @@ class ExhibitionPage extends React.Component {
     <div className="canvas-preview">
       <button
         className="canvas-preview__flex"
-        onClick={this.showCanvasDetails(canvas)}
+        onClick={this.showCanvasDetails(canvas, this.props.pageContext.annotationDetails)}
         role="link"
         type="button"
       >

--- a/src/pages/Exhibition/Exhibition.js
+++ b/src/pages/Exhibition/Exhibition.js
@@ -229,7 +229,9 @@ class ExhibitionPage extends React.Component {
                     { translate(canvas.summary, pageLanguage, '\n')
                         .split('\n')
                         .map(paragraph => <p key={`about__${paragraph}`}>{paragraph}</p>)}
-                    <p><a className="readmore" onClick={this.showCanvasDetails(canvas)}>Read More</a></p>
+                    <p>
+                      <button className="readmore" onClick={this.showCanvasDetails(canvas)}>Read More</button>
+                    </p>
                   </div>
                 </div>
               ) : (

--- a/src/pages/Object/Object.js
+++ b/src/pages/Object/Object.js
@@ -8,11 +8,6 @@ import { getTranslation as translate, getPageLanguage } from '../../utils';
 const isHtml = val => val.match(/<[^>]+>/) !== null;
 
 class ObjectPage extends React.Component {
-  propTypes = {
-    pageContext: PropTypes.object.isRequired,
-    '*': PropTypes.string.isRequired,
-  };
-
   constructor(props) {
     super(props);
     this.state = {
@@ -116,5 +111,10 @@ class ObjectPage extends React.Component {
     );
   }
 }
+
+ObjectPage.propTypes = {
+  pageContext: PropTypes.object.isRequired,
+  '*': PropTypes.string.isRequired,
+};
 
 export default ObjectPage;

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -1,0 +1,12 @@
+export default {
+  locale: 'en',
+  Menu: {
+    EXHIBITIONS: 'Exhibitions',
+    COLLECTIONS: 'Collections',
+    PUBLICATIONS: 'Publications',
+    ABOUT: 'About',
+  },
+  Header: {
+    SITE_TITLE: 'Tu Delft Academic Heritage',
+  },
+};

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -1,0 +1,7 @@
+import en from './en';
+import nl from './nl';
+
+export default {
+  en,
+  nl,
+};

--- a/src/translations/nl.js
+++ b/src/translations/nl.js
@@ -1,0 +1,12 @@
+export default {
+  locale: 'nl',
+  Menu: {
+    EXHIBITIONS: 'Tentoonstellingen',
+    COLLECTIONS: 'Collecties',
+    PUBLICATIONS: 'Publicaties',
+    ABOUT: 'Over',
+  },
+  Header: {
+    SITE_TITLE: 'Tu Delft Academisch Erfgoed',
+  },
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,4 +23,48 @@ export const getPageLanguage = (pathname) => {
   return languageCandidate === 'nl' ? languageCandidate : 'en';
 };
 
+export const thumbnailGetSize = (thumbnail, pWidth, pHeight) => {
+  const thumb = thumbnail.__jsonld;
+  if (!thumb.hasOwnProperty('service') || !(pWidth || pHeight)) {
+    return (thumb.id || thumb['@id']);
+  }
+  const service = Array.isArray(thumb.service) ? thumb.service[0] : thumb.service;
+  if (!service) {
+    return (thumb.id || thumb['@id']);
+  }
+  if (
+    service.hasOwnProperty('sizes')
+    && Array.isArray(service.sizes)
+    && service.sizes.length > 0
+  ) {
+    let closestSizeIndex = -1;
+    let minDistanceX = Number.MAX_SAFE_INTEGER;
+    let minDistanceY = Number.MAX_SAFE_INTEGER;
+    service.sizes.forEach((size, index) => {
+      if (pWidth) {
+        const xDistance = Math.abs(size.width - pWidth);
+        if (minDistanceX >= xDistance) {
+          closestSizeIndex = index;
+          minDistanceX = xDistance;
+        }
+      }
+      if (pHeight) {
+        const yDistance = Math.abs(size.height - pHeight);
+        if (minDistanceY >= yDistance) {
+          closestSizeIndex = index;
+          minDistanceY = yDistance;
+        }
+      }
+    });
+    const thumbUrlParts = (thumb.id || thumb['@id']).split('/');
+    if (closestSizeIndex !== -1) {
+      const size = service.sizes[closestSizeIndex];
+      thumbUrlParts[thumbUrlParts.length - 3] = [size.width, size.height].join(',');
+    }
+    return thumbUrlParts.join('/');
+  }
+  return (thumb.id || thumb['@id']);
+};
+
+
 export default substituteSpecialLinks;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7680,7 +7680,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
+invariant@^2.1.2, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.3, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -11805,6 +11805,13 @@ react-transition-group@2.5.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-translate@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-translate/-/react-translate-6.1.0.tgz#f1d8137684c3cd7f5a2fae541bd82ba81b18b1a1"
+  dependencies:
+    invariant "^2.1.2"
+    prop-types "^15.6.0"
 
 react@16.6.3, react@^16.3.2, react@^16.6.3:
   version "16.6.3"


### PR DESCRIPTION
(How) is it possible to load images on a publication page? -> Added examples on the [example article page](https://5c9152ec017d62000899fffd--delft-static-site-generator.netlify.com/en/publications/article-demo). 

The menu bar and site title are currently not bilingual. Is it possible to add localization for both? It’s fine if we edit this ourselves in the component files. -> Added react translations 

https://github.com/digirati-co-uk/delft-static-site-generator/pull/2/commits/ddff22f59b7322a462296d96d576c030e17446b9 

The translations folder contains the component translations.


“TypeError: Cannot read property ‘0’  -> fixed thumbnail loaders.

for example
https://5c9152ec017d62000899fffd--delft-static-site-generator.netlify.com/en/objects/multi-canvas-object json loads on site after editing

exhibition lists fixed

object backlinks fixed