### PR TITLE
Del 49/back button

### DIFF
--- a/src/components/LanguageSelector/languageSelector.js
+++ b/src/components/LanguageSelector/languageSelector.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
+import { Link } from 'gatsby';
 import './languageSelector.scss';
 
 const LanguageSelector = ({ data, path = '' }) => {
@@ -23,13 +24,13 @@ const LanguageSelector = ({ data, path = '' }) => {
   });
 
   return <span className="language-selector">
-      {allowEnglish ? <a href={allowEnglish ? englishPath : null} className="language-selector__translation">
+      {allowEnglish ? <Link to={allowEnglish ? englishPath : null} className="language-selector__translation">
           EN
-        </a> : <p title="An English translation of this page is not available" className="language-selector__translation--not-allowed">
+        </Link> : <p title="An English translation of this page is not available" className="language-selector__translation--not-allowed">
           EN
-        </p>} / {allowDutch ? <a href={allowDutch ? dutchPath : null} className="language-selector__translation">
+        </p>} / {allowDutch ? <Link to={allowDutch ? dutchPath : null} className="language-selector__translation">
           NL
-        </a> : <p title="Een Nederlandse vertaling van deze pagina is niet beschikbaar" className="language-selector__translation--not-allowed">
+        </Link> : <p title="Een Nederlandse vertaling van deze pagina is niet beschikbaar" className="language-selector__translation--not-allowed">
           NL
         </p>}
     </span>;

--- a/src/components/SlideShow/slideshow.js
+++ b/src/components/SlideShow/slideshow.js
@@ -42,7 +42,7 @@ class SlideShow extends Component {
   componentDidMount() {
     if (!this.props.id || this.canvasList.length <= this.props.id || this.props.id <= 0 || !parseInt(this.props.id)) {
       this.goToRange(0);
-      navigate(this.props.pathname)
+      navigate(this.props.pathname, {replace: true})
       return;
     };
     if (this.props.id !== this.currentIndex) {

--- a/src/pages/Object/Object.js
+++ b/src/pages/Object/Object.js
@@ -4,6 +4,7 @@ import Layout from '../../components/Layout/layout';
 import GithubLink from '../../components/GithubLink/GithubLink';
 import { getTranslation as translate, getPageLanguage } from '../../utils';
 import { IIIFLink } from '../../components/IIIFLink/IIIFLink';
+import { Link } from 'gatsby';
 
 import DynamicSlideShow from "../../components/SlideShow/dynamic-slideshow"
 
@@ -40,9 +41,9 @@ class ObjectPage extends React.Component {
                 <ol>
                   {(pageContext.collections || []).map(collection => (
                     <li key={`/${pageLanguage}/${collection[1]}`}>
-                      <a href={`/${pageLanguage}/${collection[1]}`}>
+                      <Link to={`/${pageLanguage}/${collection[1]}`}>
                         {translate(collection[2], pageLanguage)}
-                      </a>
+                      </Link>
                     </li>
                   ))}
                 </ol>
@@ -52,9 +53,9 @@ class ObjectPage extends React.Component {
                 <ol>
                   {(pageContext.exhibitions || []).map(exhibition => (
                     <li key={`/${pageLanguage}/${exhibition[1]}`}>
-                      <a href={`/${pageLanguage}/${exhibition[1]}`}>
+                      <Link to={`/${pageLanguage}/${exhibition[1]}`}>
                         {translate(exhibition[2], pageLanguage)}
-                      </a>
+                      </Link>
                     </li>
                   ))}
                 </ol>

--- a/src/pages/Publications/Publications.js
+++ b/src/pages/Publications/Publications.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import Layout from '../../components/Layout/layout';
+import { Link } from 'gatsby';
+
 import { getPageLanguage } from '../../utils';
 
 const Publications = ({ data, '*': pagePath }) => {
@@ -20,7 +22,7 @@ const Publications = ({ data, '*': pagePath }) => {
                   <div className="maintitle">
                     {title || '[Title]'}
                     <p className="readmore">
-                      <a href={path}>Read More</a>
+                      <Link to={path}>Read More</Link>
                     </p>
                   </div>
                   <div className="boxtitle">{author || '[Author]'}</div>


### PR DESCRIPTION
The previous bug with the back button has been fixed by the slideshow changes, but this PR fixes:

- The need to double click the backbutton to navigate from the slideshow back to the object

- It replaces where a tags have been used with Gatsby's link component