### PR TITLE
Del 48/publications feedback

### DIFF
--- a/content/en/publications/article-demo.md
+++ b/content/en/publications/article-demo.md
@@ -6,7 +6,7 @@ author: "Adam von Digirati"
 ---
 
 ## An Illustration
-<Illustration source="a-single-canvas-manifest.json" object="bk-otb-fotoarchief-77-5">
+<Illustration source="a-single-canvas-manifest.json">
     You can add an Illustration to your article, by putting a Manifest with a single canvas within the illustrations folder.
     The source should be the direct filename within the illustrations folder.
     Folders can be achieved if required: if you want a folder the source should read: "yourfolder/yourfile.json"

--- a/content/illustrations/a-single-canvas-manifest.json
+++ b/content/illustrations/a-single-canvas-manifest.json
@@ -8,7 +8,7 @@
     "en": [
       "A single canvas Manifest"
     ],
-    "my": [
+    "nl": [
       "Single Canvas Manifest"
     ]
   },

--- a/content/illustrations/a-single-canvas-manifest.json
+++ b/content/illustrations/a-single-canvas-manifest.json
@@ -5,13 +5,19 @@
   ],
   "type": "Manifest",
   "label": {
-    "en": ["A single canvas Manifest"],
-    "my": ["Single Canvas Manifest"]
+    "en": [
+      "A single canvas Manifest"
+    ],
+    "my": [
+      "Single Canvas Manifest"
+    ]
   },
   "items": [
     {
       "label": {
-        "en": ["Jan Ebbinge"]
+        "en": [
+          "Jan Ebbinge"
+        ]
       },
       "height": 6840,
       "width": 6960,
@@ -30,7 +36,9 @@
                 "height": 6840,
                 "width": 6960,
                 "label": {
-                  "en": ["-"]
+                  "en": [
+                    "-"
+                  ]
                 },
                 "service": {
                   "type": "ImageService2",
@@ -42,7 +50,14 @@
                     {
                       "width": 256,
                       "height": 256,
-                      "scaleFactors": [1, 2, 4, 8, 16, 32]
+                      "scaleFactors": [
+                        1,
+                        2,
+                        4,
+                        8,
+                        16,
+                        32
+                      ]
                     }
                   ],
                   "sizes": [
@@ -66,8 +81,14 @@
                   "profile": [
                     "http://iiif.io/api/image/2/level1.json",
                     {
-                      "formats": ["jpg"],
-                      "qualities": ["native", "color", "gray"],
+                      "formats": [
+                        "jpg"
+                      ],
+                      "qualities": [
+                        "native",
+                        "color",
+                        "gray"
+                      ],
                       "supports": [
                         "regionByPct",
                         "sizeByForcedWh",
@@ -91,9 +112,15 @@
                     "profile": [
                       "http://iiif.io/api/image/2/level0.json",
                       {
-                        "formats": ["jpg"],
-                        "qualities": ["color"],
-                        "supports": ["sizeByWhListed"]
+                        "formats": [
+                          "jpg"
+                        ],
+                        "qualities": [
+                          "color"
+                        ],
+                        "supports": [
+                          "sizeByWhListed"
+                        ]
                       }
                     ],
                     "width": 1024,
@@ -127,7 +154,9 @@
                 ]
               },
               "label": {
-                "en": ["Jan Ebbinge"]
+                "en": [
+                  "Jan Ebbinge"
+                ]
               }
             }
           ],
@@ -147,11 +176,16 @@
   ],
   "id": "https://delft-static-site-generator.netlify.com/iiif/1f05178d-9382-53b9-cd33-86ffd19f0476/manifest",
   "summary": {
-    "en": ["Test summary ", ""]
+    "en": [
+      "Test summary ",
+      ""
+    ]
   },
   "requiredStatement": {
     "value": {
-      "en": ["Stadsarchief Delft / TU Delft Library, Special Collections"]
+      "en": [
+        "Stadsarchief Delft / TU Delft Library, Special Collections"
+      ]
     }
   }
 }

--- a/src/components/AnnotationBodyRenderer/AnnotationBodyRenderer.js
+++ b/src/components/AnnotationBodyRenderer/AnnotationBodyRenderer.js
@@ -48,8 +48,6 @@ const IIIFImageAnnotationCover = ({
   if (!body) {
     return 'error';
   }
-  // console.log('IIIFImageAnnotationCover', body, position, annotation, canvas);
-  // const canvasPhysicalSize = convertBehaviourToPhysicalSize(canvas);
   if (body.id) {
     const imageRelativeSize = imageCanvasRealiveSize(body.id, canvas);
     canvasPhysicalSize.width /= imageRelativeSize.width;

--- a/src/components/CanvasModal/CanvasModal.js
+++ b/src/components/CanvasModal/CanvasModal.js
@@ -111,10 +111,12 @@ class CanvasModal extends React.Component {
   }
 
   getDetailsLink = imageAnnotations => {
+    console.log(imageAnnotations);
     if (imageAnnotations.length < 1) return false;
     if (this.state.currentNavIndex === -1 && this.state.navItems.length > 0)
       return false;
     let index = this.state.navItems.length > 1 ? this.state.currentNavIndex : 0;
+    console.log(this.props.annotationDetails);
     return this.props.annotationDetails[
       getAnnotationId(imageAnnotations[index])
     ];
@@ -140,6 +142,7 @@ class CanvasModal extends React.Component {
       annotation => annotation.body.type === 'Image'
     );
     const detailsLink = this.getDetailsLink(imageAnnotations);
+    console.log(detailsLink);
     return (
       <div className="canvas-modal">
         <ContainerDimensions>

--- a/src/components/CanvasModal/CanvasModal.js
+++ b/src/components/CanvasModal/CanvasModal.js
@@ -111,12 +111,10 @@ class CanvasModal extends React.Component {
   }
 
   getDetailsLink = imageAnnotations => {
-    console.log(imageAnnotations);
     if (imageAnnotations.length < 1) return false;
     if (this.state.currentNavIndex === -1 && this.state.navItems.length > 0)
       return false;
     let index = this.state.navItems.length > 1 ? this.state.currentNavIndex : 0;
-    console.log(this.props.annotationDetails);
     return this.props.annotationDetails[
       getAnnotationId(imageAnnotations[index])
     ];
@@ -142,7 +140,6 @@ class CanvasModal extends React.Component {
       annotation => annotation.body.type === 'Image'
     );
     const detailsLink = this.getDetailsLink(imageAnnotations);
-    console.log(detailsLink);
     return (
       <div className="canvas-modal">
         <ContainerDimensions>

--- a/src/components/CanvasModal/CanvasModal.scss
+++ b/src/components/CanvasModal/CanvasModal.scss
@@ -6,6 +6,7 @@
   left: 0;
   background: rgba(0,0,0,0.5);
   padding: 1rem;
+  z-index: 1;
   @media (max-width: 980px) {
     padding:0.5rem;
   }

--- a/src/components/Illustration/Illustration.js
+++ b/src/components/Illustration/Illustration.js
@@ -75,6 +75,8 @@ const IllustrationComponent = ({ source, pageLanguage, children, data }) => {
 
   useEffect(() => {
     const manifest = fetchDataFromFile(source);
+
+    console.log(manifest);
     //thumbnails from the manifest
     setIiifManifest(manifest);
 

--- a/src/components/Illustration/Illustration.js
+++ b/src/components/Illustration/Illustration.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { PropTypes } from 'prop-types';
 
 import DynamicCanvasModal from '../CanvasModal/DynamicCanvasModal';
+import { StaticQuery, graphql } from 'gatsby';
 
 const fetchDataFromFile = source => {
   const json = require(`../../../content/illustrations/${source}`);
@@ -26,31 +27,55 @@ const getThumbnail = manifest => {
   return thumbnail;
 };
 
+const getGraphThumbnail = node => {
+  if (!node.items) return [];
+  let thumbnails = node && node.items ? node.items : [];
+  thumbnails = thumbnails.map(item => {
+    if (item && item.thumbnail && item.thumbnail[0] && item.thumbnail[0].id)
+      return item.thumbnail[0].id;
+  });
+  return thumbnails;
+};
+
 const fixUrl = url => {
   return url
     .replace('thumbs', 'iiif-img')
     .replace('/full/full/0/default.jpg', '');
 };
 
-export const Illustration = ({ source, pageLanguage, object, children }) => {
+export const Illustration = ({ source, pageLanguage, children }) => {
   const [iiifmanifest, setIiifManifest] = useState({});
   const [thumbnailSrc, setThumbnailSrc] = useState('');
   const [showCanvasModal, setCanvasModal] = useState(false);
   const [annos, setAnnos] = useState([]);
+  const [paths, setPaths] = useState([]);
+  const [link, setLink] = useState('');
   useEffect(() => {
     setIiifManifest(fetchDataFromFile(source));
   }, []);
-
-  const link = object ? `objects/${object}` : '';
 
   useEffect(() => {
     const thumbnail = getThumbnail(iiifmanifest);
     const key = thumbnail.id ? fixUrl(thumbnail.id) : '';
     if (thumbnail.id) setThumbnailSrc(thumbnail.id);
     if (thumbnail.id) setAnnos({ [key]: link });
-  }, [iiifmanifest]);
+  }, [iiifmanifest, link]);
 
-  const renderModal = () => {
+  const renderModal = data => {
+    const obj = data.allSitePage.nodes.filter(node => {
+      const thumbnails = getGraphThumbnail(node.context);
+      return thumbnails.includes(thumbnailSrc);
+    });
+    setPaths(obj);
+    let _link = '';
+    if (paths.length > 1) {
+      _link = paths.find(route =>
+        route.path.split('/')[1].includes(pageLanguage)
+      ).path;
+    }
+    _link = _link.replace('/en/', '');
+    _link = _link.replace('/nl/', '');
+    setLink(_link);
     setCanvasModal(!showCanvasModal);
   };
 
@@ -58,31 +83,52 @@ export const Illustration = ({ source, pageLanguage, object, children }) => {
     iiifmanifest && iiifmanifest.items && iiifmanifest.items[0]
       ? iiifmanifest.items[0]
       : {};
+
   return (
-    <>
-      <div className="cutcorners w-7 h-4">
-        <img
-          style={{
-            objectFit: 'cover',
-            cursor: 'pointer',
-            width: '100%',
-            height: '100%',
-          }}
-          src={thumbnailSrc}
-          onClick={() => renderModal()}
-        ></img>
-      </div>
-      {children ? <div className="info cutcorners">{children}</div> : <></>}
-      {showCanvasModal ? (
-        <DynamicCanvasModal
-          manifest={iiifmanifest}
-          selectedCanvas={canvas}
-          annotationDetails={annos}
-          hideCanvasDetails={() => setCanvasModal(false)}
-          pageLanguage={pageLanguage}
-        ></DynamicCanvasModal>
-      ) : null}
-    </>
+    <StaticQuery
+      query={graphql`
+        query MyQuery {
+          allSitePage {
+            nodes {
+              path
+              context {
+                items {
+                  thumbnail {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      `}
+      render={data => (
+        <>
+          <div className="cutcorners w-7 h-4">
+            <img
+              style={{
+                objectFit: 'cover',
+                cursor: 'pointer',
+                width: '100%',
+                height: '100%',
+              }}
+              src={thumbnailSrc}
+              onClick={() => renderModal(data)}
+            ></img>
+          </div>
+          {children ? <div className="info cutcorners">{children}</div> : <></>}
+          {showCanvasModal ? (
+            <DynamicCanvasModal
+              manifest={iiifmanifest}
+              selectedCanvas={canvas}
+              annotationDetails={annos}
+              hideCanvasDetails={() => setCanvasModal(false)}
+              pageLanguage={pageLanguage}
+            ></DynamicCanvasModal>
+          ) : null}
+        </>
+      )}
+    />
   );
 };
 

--- a/src/components/Illustration/Illustration.js
+++ b/src/components/Illustration/Illustration.js
@@ -72,11 +72,11 @@ const IllustrationComponent = ({ source, pageLanguage, children, data }) => {
   const [thumbnailSrc, setThumbnailSrc] = useState([]);
   const [showCanvasModal, setCanvasModal] = useState(false);
   const [annos, setAnnos] = useState({});
+  const [label, setLabel] = useState('');
 
   useEffect(() => {
     const manifest = fetchDataFromFile(source);
-
-    console.log(manifest);
+    setLabel(manifest.label[pageLanguage]);
     //thumbnails from the manifest
     setIiifManifest(manifest);
 
@@ -128,7 +128,7 @@ const IllustrationComponent = ({ source, pageLanguage, children, data }) => {
           onClick={() => setCanvasModal(true)}
         ></img>
       </div>
-      {children ? <div className="info cutcorners">{children}</div> : <></>}
+      {label ? <div className="info cutcorners">{label}</div> : <></>}
       {showCanvasModal ? (
         <DynamicCanvasModal
           manifest={iiifmanifest}

--- a/src/components/Illustration/Illustration.js
+++ b/src/components/Illustration/Illustration.js
@@ -44,7 +44,6 @@ const getGraphThumbnail = node => {
     if (item && item.thumbnail && item.thumbnail[0] && item.thumbnail[0].id)
       return item.thumbnail[0].id;
   });
-  // console.log(thumbnails);
   return thumbnails;
 };
 

--- a/src/components/Illustration/Illustration.js
+++ b/src/components/Illustration/Illustration.js
@@ -9,22 +9,32 @@ const fetchDataFromFile = source => {
   return json;
 };
 
-const getThumbnail = manifest => {
-  if (!manifest.items) return {};
-  const thumbnail =
+const convertArrayToObject = (array, key) =>
+  array.reduce(
+    (obj, item) => ({
+      ...obj,
+      [item[key]]: item,
+    }),
+    {}
+  );
+
+const getThumbnails = manifest => {
+  if (!manifest.items) return [];
+  const items =
     manifest &&
     manifest.items &&
     manifest.items[0] &&
     manifest.items[0] &&
     manifest.items[0].items[0] &&
     manifest.items[0].items[0] &&
-    manifest.items[0].items[0].items &&
-    manifest.items[0].items[0].items[0].thumbnail &&
-    manifest.items[0].items[0].items[0].thumbnail[0] &&
-    manifest.items[0].items[0].items[0].thumbnail[0]
-      ? manifest.items[0].items[0].items[0].thumbnail[0]
-      : null;
-  return thumbnail;
+    manifest.items[0].items[0].items
+      ? manifest.items[0].items[0].items
+      : [];
+  const thumbnails = items.map(item => {
+    if (item && item.thumbnail[0] && item.thumbnail[0].id)
+      return item.thumbnail[0].id;
+  });
+  return thumbnails;
 };
 
 const getGraphThumbnail = node => {
@@ -34,7 +44,22 @@ const getGraphThumbnail = node => {
     if (item && item.thumbnail && item.thumbnail[0] && item.thumbnail[0].id)
       return item.thumbnail[0].id;
   });
+  // console.log(thumbnails);
   return thumbnails;
+};
+
+const getPath = (objects, path) => {
+  let link = '';
+  const objectPath = objects.find(object => {
+    return getGraphThumbnail(object.context).includes(path);
+  });
+  if (objectPath && objectPath.path) {
+    link = objectPath.path;
+  }
+
+  link = link.replace('/en/', '');
+  link = link.replace('/nl/', '');
+  return link;
 };
 
 const fixUrl = url => {
@@ -45,38 +70,43 @@ const fixUrl = url => {
 
 const IllustrationComponent = ({ source, pageLanguage, children, data }) => {
   const [iiifmanifest, setIiifManifest] = useState({});
-  const [thumbnailSrc, setThumbnailSrc] = useState('');
+  const [thumbnailSrc, setThumbnailSrc] = useState([]);
   const [showCanvasModal, setCanvasModal] = useState(false);
-  const [annos, setAnnos] = useState([]);
-  const [paths, setPaths] = useState([]);
-  const [link, setLink] = useState('');
-  useEffect(() => {
-    setIiifManifest(fetchDataFromFile(source));
-  }, []);
+  const [annos, setAnnos] = useState({});
 
   useEffect(() => {
-    const thumbnail = getThumbnail(iiifmanifest);
-    const key = thumbnail.id ? fixUrl(thumbnail.id) : '';
-    if (thumbnail.id) setThumbnailSrc(thumbnail.id);
-    if (thumbnail.id) setAnnos({ [key]: link });
-  }, [iiifmanifest, link]);
+    const manifest = fetchDataFromFile(source);
+    //thumbnails from the manifest
+    setIiifManifest(manifest);
 
-  useEffect(() => {
-    const obj = data.allSitePage.nodes.filter(node => {
-      const thumbnails = getGraphThumbnail(node.context);
-      return thumbnails.includes(thumbnailSrc);
+    const thumbnails = getThumbnails(manifest);
+
+    // objects which have the same thumbnails
+    const linkedObjects = data.allSitePage.nodes.filter(node => {
+      //thumbnails from the linked objects
+      const thumbs = getGraphThumbnail(node.context);
+      const intersection = thumbnails.filter(el => thumbs.includes(el));
+      return intersection.length >= 1;
     });
-    setPaths(obj);
-    let _link = '';
-    if (paths.length > 1) {
-      _link = paths.find(route =>
+
+    let languaged = [];
+    if (linkedObjects.length >= 1) {
+      languaged = linkedObjects.filter(route =>
         route.path.split('/')[1].includes(pageLanguage)
-      ).path;
+      );
     }
-    _link = _link.replace('/en/', '');
-    _link = _link.replace('/nl/', '');
-    setLink(_link);
-  }, [data]);
+    let annotations = {};
+    if (thumbnails.length >= 1) {
+      //use the first thumbnail for the annotation.
+      setThumbnailSrc(thumbnails[0]);
+      thumbnails.map(thumb => {
+        const key = thumb ? fixUrl(thumb) : '';
+        const path = getPath(languaged, thumb);
+        annotations = { ...annotations, [key]: path };
+      });
+    }
+    setAnnos(annotations);
+  }, []);
 
   const canvas =
     iiifmanifest && iiifmanifest.items && iiifmanifest.items[0]

--- a/src/components/Illustration/Illustration.js
+++ b/src/components/Illustration/Illustration.js
@@ -60,11 +60,19 @@ export const Illustration = ({ source, pageLanguage, object, children }) => {
       : {};
   return (
     <>
-      <img
-        src={thumbnailSrc}
-        style={{ cursor: 'pointer' }}
-        onClick={() => renderModal()}
-      ></img>
+      <div className="cutcorners w-7 h-4">
+        <img
+          style={{
+            objectFit: 'cover',
+            cursor: 'pointer',
+            width: '100%',
+            height: '100%',
+          }}
+          src={thumbnailSrc}
+          onClick={() => renderModal()}
+        ></img>
+      </div>
+      {children ? <div className="info cutcorners">{children}</div> : <></>}
       {showCanvasModal ? (
         <DynamicCanvasModal
           manifest={iiifmanifest}
@@ -74,7 +82,6 @@ export const Illustration = ({ source, pageLanguage, object, children }) => {
           pageLanguage={pageLanguage}
         ></DynamicCanvasModal>
       ) : null}
-      {children}
     </>
   );
 };


### PR DESCRIPTION
This PR addresses the following feedback from the client - with the exception of point 5, which is a bit of work to get this integrated so will come back to this if time allows.


1) Could you apply the same CSS styles to the images and captions as the existing images in the demo article? I.e. the cut corner image with the caption in a black box.
2) The CSS in the modal seems incorrect; is it possible to use the same styles as in the exhibition modals?
3) Could the caption be taken from the IIIF-json, like in the exhibitions? (Rather than in the markdown file.)
4) Could the relationships between images and items be made by the static site rather than manually (with object=""bk-otb-fotoarchief-77-5"")? If the image is used on an object page, there can always be a 'view details' link. I did note that the 'view details' link does navigate to the right image within in the manifest, which is perfect.
5) Related to previous, could you add a block to the left of the object page with the title 'Part of Publications', containing links to the publication(s) in which (an) image(s) from the manifest is/are used? Ideally, the link would even contain a page anchor to the correct section of the article.
6) [Added 5/3] When scrolling outside of the modal image canvas, links and other images of the article beneath move over the front modal"